### PR TITLE
Project5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <jmh.version>1.37</jmh.version>
+
 
         <maven.version>3.8.8</maven.version>
         <jdk.version>21</jdk.version>
@@ -67,6 +69,18 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- JMH -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>

--- a/src/test/java/edu/Project5/ReflectionBenchmark.java
+++ b/src/test/java/edu/Project5/ReflectionBenchmark.java
@@ -1,0 +1,94 @@
+package edu.Project5;
+import java.lang.invoke.CallSite;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+@State(Scope.Thread)
+public class ReflectionBenchmark {
+    public static void main(String[] args) throws RunnerException {
+        Options options = new OptionsBuilder()
+            .include(ReflectionBenchmark.class.getSimpleName())
+            .shouldFailOnError(true)
+            .shouldDoGC(true)
+            .mode(Mode.AverageTime)
+            .timeUnit(TimeUnit.NANOSECONDS)
+            .forks(1)
+            .warmupForks(1)
+            .warmupIterations(1)
+            .warmupTime(TimeValue.seconds(5))
+            .measurementIterations(1)
+            .measurementTime(TimeValue.seconds(5))
+            .build();
+
+        new Runner(options).run();
+    }
+
+    record Student(String name, String surname) {
+    }
+
+    private Student student;
+    private Method method;
+    private MethodHandle methodHandle;
+    private Function<Student, String> lambda;
+
+
+
+    @Setup
+    public void setup() throws Throwable {
+        student = new Student("Alexander", "Biryukov");
+        method = student.getClass().getMethod("name");
+
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        MethodType mt = MethodType.methodType(String.class);
+        methodHandle = lookup.findVirtual(Student.class, "name", mt);
+
+        CallSite site = LambdaMetafactory.metafactory(MethodHandles.lookup(),
+            "apply",
+            MethodType.methodType(Function.class),
+            MethodType.methodType(Object.class, Object.class),
+            methodHandle,
+            methodHandle.type());
+        lambda = (Function<Student, String>) site.getTarget().invokeExact();
+    }
+
+    @Benchmark
+    public void directAccess(Blackhole bh) {
+        String name = student.name();
+        bh.consume(name);
+    }
+
+    @Benchmark
+    public void reflection(Blackhole bh) throws InvocationTargetException, IllegalAccessException {
+        String name = (String) method.invoke(student);
+        bh.consume(name);
+    }
+
+    @Benchmark
+    public void methodHandles(Blackhole bh) throws Throwable {
+        String name = (String) methodHandle.invokeExact(student);
+        bh.consume(name);
+    }
+
+    @Benchmark
+    public void lambda(Blackhole bh) throws Throwable {
+        String name = lambda.apply(student);
+        bh.consume(name);
+    }
+}


### PR DESCRIPTION
| Benchmark                                   | Mode | Cnt | Score | Error | Units |
|---------------------------------------------|------|-----|-------|-------|-------|
| Project5.ReflectionBenchmark.directAccess   | avgt | 5   | 0,564 | ± 0,017 | ns/op |
| Project5.ReflectionBenchmark.lambda         | avgt | 5   | 0,799 | ± 0,009 | ns/op |
| Project5.ReflectionBenchmark.methodHandles  | avgt | 5   | 2,887 | ± 0,150 | ns/op |
| Project5.ReflectionBenchmark.reflection     | avgt | 5   | 6,031 | ± 0,047 | ns/op |